### PR TITLE
Harvesting (#110)

### DIFF
--- a/R/Params/caribou_management_areas.Rmd
+++ b/R/Params/caribou_management_areas.Rmd
@@ -80,8 +80,14 @@ Below is a script to create rasters and constraint tables for BC critical habita
 ```{r, scenario: bc critical habitat, no harvest in high elevation, 15% max disturbance in low elevation, 35% max disturbance in matrix}
 conn <- DBI::dbConnect (dbDriver ("PostgreSQL"), host = keyring::key_get ('dbhost', keyring = 'postgreSQL'), dbname = keyring::key_get('dbname', keyring = 'postgreSQL'), port='5432' ,user=keyring::key_get('dbuser', keyring = 'postgreSQL') ,password= keyring::key_get('dbpass', keyring = 'postgreSQL'))
 #bc.crit<-getSpatialQuery("SELECT * from bc_caribou_core_matrix_habitat_v20190904_1;") # old version
-bc.crit<-getSpatialQuery("SELECT * from bc_caribou_linework_v20200507_shp_core_matrix;") # 
-# NEEDS update to bc_critical_habitat_all_herds_20200615
+#bc.crit<-getSpatialQuery("SELECT * from bc_caribou_linework_v20200507_shp_core_matrix;") # old version
+bc.crit<-getSpatialQuery("SELECT * from bc_critical_habitat_all_herds_20200615;") # current version
+prov.rast <- raster::raster ( # standardized provincial raster with no data in it
+                              nrows = 15744, ncols = 17216, 
+                              xmn = 159587.5, xmx = 1881187.5, 
+                              ymn = 173787.5, ymx = 1748187.5, 
+                              crs = st_crs(bc.crit)$proj4string, resolution = c(100, 100), 
+                              vals = 0)
 
 #all - create the raster for each herd and critical habitat type
 all.bc<-bc.crit
@@ -100,9 +106,14 @@ writeRaster(ras.all.bc, "bccrithab.tif", overwrite = TRUE)
 system("cmd.exe", input = paste0('raster2pgsql -s 3005 -d -I -C -M -N 2147483648  ', here::here(), '/R/params/bccrithab.tif -t 100x100 rast.bc_crithab | psql postgres://', keyring::key_get('dbuser', keyring = 'postgreSQL'), ':', keyring::key_get('dbpass', keyring = 'postgreSQL'), '@', keyring::key_get('dbhost', keyring = 'postgreSQL'), ':5432/clus'), show.output.on.console = FALSE, invisible = TRUE)
 
 #c("Rainbows","Charlotte_Alplands", "Itcha_Ilgachuz", "Groundhog", "Monashee", "Barkerville",  "Telkwa", "Central_Rockies","Central_Selkirks","Columbia_North","Columbia_South","Frisby_Boulder", "Purcell_Central","Purcell_South","South_Selkirks","Wells_Gray_South","Narrow_Lake","North_Cariboo","Wells_Gray_North","Hart_Ranges","Redrock_Prairie_Creek")
-herds<-c("Barkerville", "Graham", "Groundhog",  "Moberly",  "Burnt_Pine", "Monashee","Narraway", "Quintette" ,  "Rainbows", "Telkwa",  "Itcha_Ilgachuz",  "Central_Rockies", "Central_Selkirks" ,  "Charlotte_Alplands", "Columbia_North", "Columbia_South", "Frisby_Boulder","Hart_Ranges",         "Kennedy_Siding","Narrow_Lake", "North_Cariboo" , "Purcell_Central",  "Purcells_South", "South_Selkirks", "Wells_Gray_North", "Wells_Gray_South", "Redrock_Prairie_Creek") # list of herd names in the polygon data; can customize the list to add/remove
+herds<-c("Barkerville", "Burnt_Pine", "Groundhog", "Moberly", "Monashee", "Narraway", "Central_Rockies",
+         "Quintette", "Rainbows", "Tweedsmuir", "Narrow_Lake",  "Takla",  
+         "Itcha_Ilgachuz",  "Central_Selkirks", "Charlotte_Alplands", "Columbia_North", "Columbia_South",
+         "Frisby_Boulder", "Hart_Ranges", "Kennedy_Siding", "North_Cariboo", "Purcell_Central", "Purcells_South",
+         "South_Selkirks", "Wells_Gray_North", "Wells_Gray_South", "Redrock_Prairie_Creek" ) # list of herd names in the polygon data; can customize the list to add/remove
+         # "Atlin", "Edziza", "Finlay", "Frog", "Gataga", "Horseranch", "Thutade", "Tsenaglode", "Carcross",  "Liard_Plateau", 
+        # "Level_Kawdy", "Little_Rancheria", "Swan_Lake", "George_Mountain", "Graham", "Telkwa", "Calendar",  "Chase", "Chinchaga", "Maxhamish", "Rabbit" , "Spatsizi", "Wolverine", "Muskwa", "Snake_Sahtaneh", "Westside_Fort_Nelson",  "Scott",  "Pink_Mountain"
 
-#herds<-c("Narrow_Lake","North_Cariboo")
 for(herd in herds){ # create a table of the constraints for each herd
   bc.crit.selected<-eval(parse(text = paste0("bc.crit[bc.crit$herd_name == '", 
                                              herd,"',]")))
@@ -123,6 +134,7 @@ for(herd in herds){ # create a table of the constraints for each herd
   eccc.vat[, type:= 'ge'] # greater than or equal to (ge), less than or equal to (le)
   eccc.vat[, ndt:= 0]
   eccc.vat[, threshold:= 500] # threshold from disturbance (500 m)
+  eccc.vat[, multi_condition:= '']
   eccc.vat[ crithab %in% c('Matrix'), percentage:= 85] # percentage of area where constraint applies, e.g., in this case, 85% ge 500m
   eccc.nh.zones<-eccc.vat[is.na(percentage), zoneid] # where there is no constaint, make it a 'no harvest' zone
   
@@ -130,8 +142,8 @@ for(herd in herds){ # create a table of the constraints for each herd
   ras.eccc[ras.eccc[] %in% eccc.nh.zones]<-0
   
   zone.eccc.crithab<-eccc.vat[!(zoneid %in% eccc.nh.zones),]
-  zone.eccc.crithab<-zone.eccc.crithab[, c('zoneid', 'reference_zone', 'ndt', 'variable', 'threshold','type','percentage' )]
-  zone.eccc.crithab.nh<-data.table(zoneid =0, reference_zone = paste0('rast.zone_cond_eccc_', tolower(herd),'_crithab'), ndt =0, variable ='', threshold = 0, type = 'nh', percentage =0)
+  zone.eccc.crithab<-zone.eccc.crithab[, c('zoneid', 'reference_zone', 'ndt', 'variable', 'threshold','type','percentage', 'multi_condition')]
+  zone.eccc.crithab.nh<-data.table(zoneid =0, reference_zone = paste0('rast.zone_cond_eccc_', tolower(herd),'_crithab'), ndt =0, variable ='', threshold = 0, type = 'nh', percentage =0, multi_condition = '')
 
   zone.eccc.crithab<-rbindlist(list(zone.eccc.crithab, zone.eccc.crithab.nh))
   writeRaster(ras.eccc, "rasecccrit.tif", overwrite = TRUE)
@@ -139,6 +151,7 @@ for(herd in herds){ # create a table of the constraints for each herd
   zone.eccc.crithab<-zone.eccc.crithab[,zoneid:=as.integer(zoneid)]
   zone.eccc.crithab<-zone.eccc.crithab[,ndt:=as.integer(ndt)]
   zone.eccc.crithab<-zone.eccc.crithab[,threshold:=as.numeric(threshold)]
+  zone.eccc.crithab<-zone.eccc.crithab[,multi_condition:=as.character(multi_condition)]
 
   conn<-DBI::dbConnect(dbDriver("PostgreSQL"), host=keyring::key_get('dbhost', keyring = 'postgreSQL'), dbname = keyring::key_get('dbname', keyring = 'postgreSQL'), port='5432' ,user=keyring::key_get('dbuser', keyring = 'postgreSQL') ,password= keyring::key_get('dbpass', keyring = 'postgreSQL'))
 
@@ -155,6 +168,7 @@ for(herd in herds){ # create a table of the constraints for each herd
   bc.vat[, variable:= 'dist']
   bc.vat[, type:= 'ge']
   bc.vat[, threshold:= 500]
+  bc.vat[, multi_condition:= '']
   bc.vat[ crithab %in% c('Matrix'), percentage:= 65]
   bc.vat[ crithab %in% c('Matrix'), threshold:= 0]
   bc.vat[ crithab %in% c('LEWR', 'LEWSR'), percentage:= 85]
@@ -165,13 +179,14 @@ for(herd in herds){ # create a table of the constraints for each herd
   writeRaster(ras.bc, "rasbccrit.tif", overwrite = TRUE)
   
   zone.bc.crithab<-bc.vat[!(zoneid %in% bc.nh.zones),]
-  zone.bc.crithab<-zone.bc.crithab[, c('zoneid', 'reference_zone', 'ndt', 'variable', 'threshold','type','percentage' )]
-  zone.bc.crithab.nh<-data.table(zoneid =0, reference_zone = paste0('rast.zone_cond_bc_', tolower(herd),'_crithab'), ndt =0, variable ='', threshold = 0, type = 'nh', percentage =0)
+  zone.bc.crithab<-zone.bc.crithab[, c('zoneid', 'reference_zone', 'ndt', 'variable', 'threshold','type','percentage', 'multi_condition' )]
+  zone.bc.crithab.nh<-data.table(zoneid =0, reference_zone = paste0('rast.zone_cond_bc_', tolower(herd),'_crithab'), ndt =0, variable ='', threshold = 0, type = 'nh', percentage =0, multi_condition = NA)
 
   zone.bc.crithab<-rbindlist(list(zone.bc.crithab, zone.bc.crithab.nh))
   zone.bc.crithab<-zone.bc.crithab[,zoneid:=as.integer(zoneid)]
   zone.bc.crithab<-zone.bc.crithab[,ndt:=as.integer(ndt)]
   zone.bc.crithab<-zone.bc.crithab[,threshold:=as.numeric(threshold)]
+  zone.bc.crithab<-zone.bc.crithab[,multi_condition:=as.character(multi_condition)]
   
   conn<-DBI::dbConnect(dbDriver("PostgreSQL"), host=keyring::key_get('dbhost', keyring = 'postgreSQL'), dbname = keyring::key_get('dbname', keyring = 'postgreSQL'), port='5432' ,user=keyring::key_get('dbuser', keyring = 'postgreSQL') ,password= keyring::key_get('dbpass', keyring = 'postgreSQL'))
 
@@ -181,7 +196,7 @@ for(herd in herds){ # create a table of the constraints for each herd
 
 #upload to db
   system("cmd.exe", input = paste0('raster2pgsql -s 3005 -d -I -C -M -N 2147483648  ', here::here(), '/R/params/rasbccrit.tif -t 100x100', paste0(' rast.zone_cond_bc_', tolower(herd),'_crithab'),' | psql postgres://', keyring::key_get('dbuser', keyring = 'postgreSQL'), ':', keyring::key_get('dbpass', keyring = 'postgreSQL'), '@', keyring::key_get('dbhost', keyring = 'postgreSQL'), ':5432/clus'), show.output.on.console = FALSE, invisible = TRUE)
-
+  gc()
 }
 
 ```

--- a/R/SpaDES-modules/dataLoaderCLUS/dataLoaderCLUS.R
+++ b/R/SpaDES-modules/dataLoaderCLUS/dataLoaderCLUS.R
@@ -46,6 +46,7 @@ defineModule(sim, list(
     defineParameter("save_clusdb", "logical", FALSE, NA, NA, desc = "Save the db to a file?"),
     defineParameter("useCLUSdb", "character", "99999", NA, NA, desc = "Use an exising db? If no, set to 99999. IOf yes, put in the postgres database name here (e.g., clus)."),
     defineParameter("nameZoneRasters", "character", "99999", NA, NA, desc = "Administrative boundary containing zones of management objectives"),
+    defineParameter("nameZonePriorityRaster", "character", "99999", NA, NA, desc = "Boundary of zones where harvesting should be prioritized"),
     defineParameter("nameCompartmentRaster", "character", "99999", NA, NA, desc = "Name of the raster in a pg db that represents a compartment or supply block. Not currently in the pgdb?"),
     defineParameter("nameCompartmentTable", "character", "99999", NA, NA, desc = "Name of the table in a pg db that represents a compartment or supply block value attribute look up. CUrrently 'study_area_compart'?"),
     defineParameter("nameMaskHarvestLandbaseRaster", "character", "99999", NA, NA, desc = "Administrative boundary related to operability of the the timber harvesting landbase. This mask is between 0 and 1, representing where its feasible to harvest"),
@@ -100,7 +101,8 @@ doEvent.dataLoaderCLUS = function(sim, eventTime, eventType, debug = FALSE) {
         #populate clusdb tables
         sim <- setTablesCLUSdb(sim)
         sim <- setIndexesCLUSdb(sim) # creates index to facilitate db querying?
-        sim <- calcForestState(sim)
+        sim <- scheduleEvent(sim, eventTime = 0,  "dataLoaderCLUS", "forestStateNetdown", eventPriority=90)
+        
        }else{
          #copy existing clusdb
         sim$foreststate<-NULL
@@ -139,9 +141,11 @@ doEvent.dataLoaderCLUS = function(sim, eventTime, eventType, debug = FALSE) {
       sim <- scheduleEvent(sim, eventTime = end(sim),  "dataLoaderCLUS", "removeDbCLUS", eventPriority=99)
       
       },
+    forestStateNetdown={
+      sim <- calcForestState(sim)
+    },
     removeDbCLUS={
-      sim<- disconnectDbCLUS(sim)
-      
+      sim <- disconnectDbCLUS(sim)
     },
     warning(paste("Undefined event type: '", current(sim)[1, "eventType", with = FALSE],
                   "' in module '", current(sim)[1, "moduleName", with = FALSE], "'", sep = ""))
@@ -173,7 +177,7 @@ createCLUSdb <- function(sim) {
   dbExecute(sim$clusdb, "CREATE TABLE IF NOT EXISTS zone (zone_column text, reference_zone text)")
   dbExecute(sim$clusdb, "CREATE TABLE IF NOT EXISTS zoneConstraints ( id integer PRIMARY KEY, zoneid integer, reference_zone text, zone_column text, ndt integer, variable text, threshold numeric, type text, percentage numeric, multi_condition text, t_area numeric)")
   dbExecute(sim$clusdb, "CREATE TABLE IF NOT EXISTS pixels ( pixelid integer PRIMARY KEY, compartid character, 
-own integer, yieldid integer, yieldid_trans integer, zone_const integer DEFAULT 0, thlb numeric , elv numeric DEFAULT 0, age numeric, vol numeric,
+own integer, yieldid integer, yieldid_trans integer, zone_const integer DEFAULT 0, thlb numeric , elv numeric DEFAULT 0, age numeric, vol numeric, dist numeric DEFAULT 0,
 crownclosure numeric, height numeric, siteindex numeric, dec_pcnt numeric, eca numeric, roadyear integer)")
   return(invisible(sim))
 }
@@ -294,10 +298,11 @@ setTablesCLUSdb <- function(sim) {
     }
     # zone_constraint table
     if(!P(sim)$nameZoneTable == '99999'){
-      
-      zone_const<-getTableQuery(paste0("SELECT * FROM ", P(sim)$nameZoneTable)) # get all zones across the province from the zone table in the pgdb
       zone<-dbGetQuery(sim$clusdb, "SELECT * FROM zone") # select the name of the raster and its column name in pixels
       #Select only those constraints that pertain to the study area
+      zone_const<-getTableQuery(paste0("SELECT * FROM ", P(sim)$nameZoneTable, " WHERE reference_zone IN('",
+                                       paste(zone$reference_zone, sep ="", collapse ="','" ),"');")) # get all zones across the province from the zone table in the pgdb
+      
       zone_const<-merge(zone_const, zone, by = 'reference_zone') #merge the two together so that the provincial constraints include the zonecolumn from pixels
       
       #for each constraint zone estimate the total area from which to apply the constraint
@@ -326,6 +331,36 @@ setTablesCLUSdb <- function(sim) {
     pixels[, zone1:= 1]
     dbExecute(sim$clusdb, "ALTER TABLE pixels ADD COLUMN zone1 integer")
     dbExecute(sim$clusdb, paste0("INSERT INTO zone (zone_column, reference_zone) values ( 'zone1', 'default')" ))
+  }
+  #------------
+  #Set the zonePriorityRaster
+  #------------
+  if(!P(sim)$nameZonePriorityRaster == '99999'){
+    #Check to see if the name of the zone priority raster is already in the zone table
+    if(!P(sim)$nameZonePriorityRaster %in% dbGetQuery(sim$clusdb, "SELECT reference_zone from zone")$reference_zone){
+      message(paste0('.....zone priority raster not in zones table...fetching: ',P(sim, "dataLoaderCLUS", "nameZonePriorityRaster")))
+      ras.zone.priority<- RASTER_CLIP2(tmpRast =sim$boundaryInfo[[3]], 
+                             srcRaster= P(sim, "dataLoaderCLUS", "nameZonePriorityRaster"), 
+                             clipper=P(sim, "dataLoaderCLUS", "nameBoundaryFile"), 
+                             geom= P(sim, "dataLoaderCLUS", "nameBoundaryGeom"), 
+                             where_clause =  paste0(P(sim, "dataLoaderCLUS", "nameBoundaryColumn"), " in (''", paste(sim$boundaryInfo[[3]], sep = "' '", collapse= "'', ''") ,"'')"),
+                             conn=NULL)
+      if(aoi == extent(ras.zone.priority)){#need to check that each of the extents are the same
+        pixels<-cbind(pixels, data.table(c(t(raster::as.matrix(ras.zone.priority)))))
+        zone.priority<-paste0("zone", as.character(nrow(dbGetQuery(sim$clusdb, "SELECT * FROM zone")) + 1))
+        setnames(pixels, "V1", zone.priority)
+        #Add the zone priority column to the zone table
+        dbExecute(sim$clusdb, paste0("INSERT INTO zone (zone_column, reference_zone) values ('",zone.priority, "', '",P(sim, "dataLoaderCLUS", "nameZonePriorityRaster"),"')"))
+        #Add the column name to pixels
+        dbExecute(sim$clusdb, paste0("ALTER TABLE pixels ADD COLUMN ",zone.priority," integer"))
+        #Add to the zone.length needed when inserting the pixels table
+        sim$zone.length<-sim$zone.length + 1
+        rm(ras.zone.priority,zone.priority)
+        gc()
+      }else{
+        stop(paste0("ERROR: extents are not the same check -", P(sim, "dataLoaderCLUS", "nameZonePriorityRaster")))
+      }
+    }
   }
   
   #------------
@@ -715,6 +750,9 @@ sim$foreststate<- data.table(dbGetQuery(sim$clusdb, paste0("SELECT compartid as 
               in('",paste(sim$boundaryInfo[[3]], sep = " ", collapse = "','"),"')
                          group by compartid;"))
             )
+test_foreststate<<-sim$foreststate
+test_roads<<-dbGetQuery(sim$clusdb, "select sum(case when roadyear >= -1  then 1 else 0 end) as road
+           FROM pixels  where compartid is not null ")
   return(invisible(sim))
 }
 

--- a/R/SpaDES-modules/dataLoaderCLUS/dataLoaderCLUS_100miletsa.Rmd
+++ b/R/SpaDES-modules/dataLoaderCLUS/dataLoaderCLUS_100miletsa.Rmd
@@ -105,7 +105,7 @@ parameters <-  list(
                                      keyring::key_get("vmdbpass", keyring="postgreSQL"),  
                                      keyring::key_get("vmdbname", keyring="postgreSQL"))),
   yieldUncertaintyCLUS = list (elevationRaster = 'rast.dem'), 
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval = 1, 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail", 

--- a/R/SpaDES-modules/dataLoaderCLUS/dataLoaderCLUS_revelstoketsa.Rmd
+++ b/R/SpaDES-modules/dataLoaderCLUS/dataLoaderCLUS_revelstoketsa.Rmd
@@ -73,7 +73,14 @@ parameters <-  list(
                             "rast.zone_cond_eccc_columbia_south_crithab_or_herd",
                             "rast.zone_cond_eccc_central_rockies_crithab_or_herd",
                             "rast.zone_cond_eccc_columbia_north_crithab_or_herd",
-                            "rast.zone_cond_reve_area"
+                            "rast.zone_cond_reve_area",
+                            
+                            # add these?
+                            "rast.zone_cond_bc_columbia_north_crithab",
+                            "rast.zone_cond_bc_columbia_south_crithab",
+                            "rast.zone_cond_bc_central_rockies_crithab",
+                            "rast.zone_cond_bc_frisby_boulder_crithab",
+                            "rast.zone_cond_bc_monashee_crithab",
                                              ), 
                          nameZoneTable = "zone_constraints", 
                          nameYieldsRaster = "rast.ycid_vdyp", 

--- a/R/SpaDES-modules/disturbanceCalcCLUS/disturbanceCalcCLUS.R
+++ b/R/SpaDES-modules/disturbanceCalcCLUS/disturbanceCalcCLUS.R
@@ -114,7 +114,6 @@ Init <- function(sim) {
   if(dbGetQuery (sim$clusdb, "SELECT COUNT(*) as exists_check FROM pragma_table_info('pixels') WHERE name='perm_dist';")$exists_check == 0){
     # add in the column
     dbExecute(sim$clusdb, "ALTER TABLE pixels ADD COLUMN perm_dist integer DEFAULT 0")
-    dbExecute(sim$clusdb, "ALTER TABLE pixels ADD COLUMN dist numeric DEFAULT 0")
     # add in the raster
     if(P(sim, "disturbanceCalcCLUS", "permDisturbanceRaster") == '99999'){
       message("WARNING: No permanent disturbance raster specified ... defaulting to no permanent disturbances")
@@ -156,14 +155,14 @@ distAnalysis <- function(sim) {
   if(nrow(all.dist) > 0){
     outPts<-merge(sim$disturbance, all.dist, by = 'pixelid', all.x =TRUE) 
     message("Get the cutblock summaries")
-    cutblock_summary<-Reduce(merge,
-    list(outPts[, .(total_area = uniqueN(.I)), by = "critical_hab"],
-         outPts[blockid > 0 & age >= 0 & age <= 20 & !is.na(critical_hab), .(cut20 = uniqueN(.I)), by = "critical_hab"],
-         outPts[blockid > 0 & age >= 0 & age <= 40 & !is.na(critical_hab), .(cut40 = uniqueN(.I)), by = "critical_hab"],
-         outPts[blockid > 0 & age >= 0 & age <= 80 & !is.na(critical_hab), .(cut80 = uniqueN(.I)), by = "critical_hab"],
-         outPts[blockid > 0 & age >= 10 & age <= 40 & !is.na(critical_hab), .(cut10_40 = uniqueN(.I)), by = "critical_hab"]
-    ))
-    
+    cutblock_summary<-Filter(function(x) dim(x)[1] > 0,
+         list(outPts[, .(total_area = uniqueN(.I)), by = "critical_hab"],
+              outPts[blockid > 0 & age >= 0 & age <= 20 & !is.na(critical_hab), .(cut20 = uniqueN(.I)), by = "critical_hab"],
+              outPts[blockid > 0 & age >= 0 & age <= 40 & !is.na(critical_hab), .(cut40 = uniqueN(.I)), by = "critical_hab"],
+              outPts[blockid > 0 & age >= 0 & age <= 80 & !is.na(critical_hab), .(cut80 = uniqueN(.I)), by = "critical_hab"],
+              outPts[blockid > 0 & age >= 10 & age <= 40 & !is.na(critical_hab), .(cut10_40 = uniqueN(.I)), by = "critical_hab"]
+    ))  %>%
+      Reduce(function(dtf1,dtf2) full_join(dtf1,dtf2, by="critical_hab"), .)
     message("Get the Road summaries")
     outPts[roadyear >=0, field:=0]
     nearNeigh_rds<-RANN::nn2(outPts[field == 0 & !is.na(critical_hab), c('x', 'y')], 
@@ -172,12 +171,13 @@ distAnalysis <- function(sim) {
   
     outPts<-outPts[is.na(field)  & !is.na(critical_hab), rds_dist:=nearNeigh_rds$nn.dists] # assign the distances
     outPts[is.na(rds_dist) & !is.na(critical_hab), rds_dist:=0] # those that are the distance to pixels, assign 
-    road_summary<-Reduce(merge,
+    road_summary<-Filter(function(x) dim(x)[1] > 0,
                              list(outPts[rds_dist == 0  & !is.na(critical_hab), .(road50 = uniqueN(.I)), by = "critical_hab"],
                                   outPts[rds_dist <= 250 & !is.na(critical_hab), .(road250 = uniqueN(.I)), by = "critical_hab"],
                                   outPts[rds_dist <= 500 & !is.na(critical_hab), .(road500  = uniqueN(.I)), by = "critical_hab"],
                                   outPts[rds_dist <= 750 & !is.na(critical_hab), .(road750  = uniqueN(.I)), by = "critical_hab"]
-                             ))
+                             )) %>%
+      Reduce(function(dtf1,dtf2) full_join(dtf1,dtf2, by="critical_hab"), .)
     outPts<-outPts[,c("rds_dist","field") := list(NULL, NA)]
     
     message("Cutblocks and roads combined")
@@ -188,12 +188,13 @@ distAnalysis <- function(sim) {
     
     outPts<-outPts[is.na(field) & !is.na(critical_hab), dist:=nearNeigh$nn.dists] # assign the distances
     outPts[is.na(dist) & !is.na(critical_hab), dist:=0] # those that are the distance to pixels, assign 
-    c40r<-Reduce(merge,
+    c40r<-Filter(function(x) dim(x)[1] > 0,
                          list(outPts[dist == 0  & !is.na(critical_hab), .(c40r50 = uniqueN(.I)), by = "critical_hab"],
                               outPts[dist <= 250 & !is.na(critical_hab), .(c40r250 = uniqueN(.I)), by = "critical_hab"],
                               outPts[dist <= 500 & !is.na(critical_hab), .(c40r500  = uniqueN(.I)), by = "critical_hab"],
                               outPts[dist <= 750 & !is.na(critical_hab), .(c40r750  = uniqueN(.I)), by = "critical_hab"]
-                         ))
+                         )) %>%
+      Reduce(function(dtf1,dtf2) full_join(dtf1,dtf2, by="critical_hab"), .)
     
     outPts<-outPts[,c("dist","field") := list(NULL, NA)]
     
@@ -204,10 +205,11 @@ distAnalysis <- function(sim) {
     
     outPts<-outPts[is.na(field) & !is.na(critical_hab), dist:=nearNeigh$nn.dists] # assign the distances
     outPts[is.na(dist) & !is.na(critical_hab), dist:=0] # those that are the distance to pixels, assign 
-    c10_40r<-Reduce(merge,
+    c10_40r<-Filter(function(x) dim(x)[1] > 0,
                  list(outPts[dist == 0  & !is.na(critical_hab), .(c10_40r50 = uniqueN(.I)), by = "critical_hab"],
                       outPts[dist <= 500 & !is.na(critical_hab), .(c10_40r500  = uniqueN(.I)), by = "critical_hab"]
-                 ))
+                 )) %>%
+      Reduce(function(dtf1,dtf2) full_join(dtf1,dtf2, by="critical_hab"), .)
     
     outPts<-outPts[,c("dist","field") := list(NULL, NA)]
     
@@ -218,12 +220,13 @@ distAnalysis <- function(sim) {
     
     outPts<-outPts[is.na(field) & !is.na(critical_hab), dist:=nearNeigh$nn.dists] # assign the distances
     outPts[is.na(dist) & !is.na(critical_hab), dist:=0] # those that are the distance to pixels, assign 
-    c20r<-Reduce(merge,
+    c20r<-Filter(function(x) dim(x)[1] > 0,
                  list(outPts[dist == 0  & !is.na(critical_hab), .(c20r50 = uniqueN(.I)), by = "critical_hab"],
                       outPts[dist < 250 & !is.na(critical_hab), .(c20r250 = uniqueN(.I)), by = "critical_hab"],
                       outPts[dist < 500 & !is.na(critical_hab), .(c20r500  = uniqueN(.I)), by = "critical_hab"],
                       outPts[dist < 750 & !is.na(critical_hab), .(c20r750  = uniqueN(.I)), by = "critical_hab"]
-                 ))
+                 )) %>%
+      Reduce(function(dtf1,dtf2) full_join(dtf1,dtf2, by="critical_hab"), .)
     outPts<-outPts[,c("dist","field") := list(NULL, NA)]
     
     outPts[roadyear >=0 | (blockid > 0 & age >=0 & age <= 80), field:=0]
@@ -234,12 +237,13 @@ distAnalysis <- function(sim) {
     outPts<-outPts[is.na(field) & !is.na(critical_hab), dist:=nearNeigh$nn.dists] # assign the distances
     outPts[is.na(dist) & !is.na(critical_hab), dist:=0] # those that are the distance to pixels, assign 
     
-    c80r<-Reduce(merge,
+    c80r<-Filter(function(x) dim(x)[1] > 0,
                  list(outPts[dist == 0  & !is.na(critical_hab), .(c80r50 = uniqueN(.I)), by = "critical_hab"],
                       outPts[dist <= 250 & !is.na(critical_hab), .(c80r250 = uniqueN(.I)), by = "critical_hab"],
                       outPts[dist <= 500 & !is.na(critical_hab), .(c80r500  = uniqueN(.I)), by = "critical_hab"],
                       outPts[dist <= 750 & !is.na(critical_hab), .(c80r750  = uniqueN(.I)), by = "critical_hab"]
-                 ))
+                 )) %>%
+      Reduce(function(dtf1,dtf2) full_join(dtf1,dtf2, by="critical_hab"), .)
     sim$disturbance<-merge(sim$disturbance, outPts[,c("pixelid","dist")], by = 'pixelid', all.x =TRUE) #sim$rsfcovar contains: pixelid, x,y, population
     
     #update the pixels table
@@ -257,13 +261,16 @@ distAnalysis <- function(sim) {
   #writeRaster(out.ras, paste0("dist",time(sim), ".tif"), overwrite = TRUE)
   
   #TODO:Add the volume from harvestPixelList; but see volumebyareaReportCLUS
-  tempDisturbanceReport<-Reduce(merge,list(cutblock_summary, road_summary, c80r,c40r,c20r, c10_40r)
-  )
+  tempDisturbanceReport<-data.table(Filter(function(x) dim(x)[1] > 0,
+                                list (cutblock_summary, road_summary, c80r, c40r, c20r, c10_40r)) %>%
+                                  Reduce(function(dtf1,dtf2) full_join(dtf1,dtf2, by="critical_hab"), .))
+  
   
   tempDisturbanceReport[, c("scenario", "compartment", "timeperiod") := 
                           list(scenario$name,sim$boundaryInfo[[3]],time(sim)*sim$updateInterval)]
   
-  sim$disturbanceReport<-rbindlist(list(sim$disturbanceReport, tempDisturbanceReport), use.names=TRUE )
+  sim$disturbanceReport<-rbindlist(list(sim$disturbanceReport, tempDisturbanceReport), use.names=TRUE, 
+                                   fill = TRUE )
   sim$disturbance[, dist:=NULL]
   
   return(invisible(sim))

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS.R
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS.R
@@ -35,7 +35,9 @@ defineModule(sim, list(
     defineParameter(".useCache", "logical", FALSE, NA, NA, "Should this entire module be run with caching activated? This is generally intended for data-type modules, where stochasticity and time are not relevant"),
     defineParameter("adjacencyConstraint", "numeric", 9999, NA, NA, "Include Adjacency Constraint at the user specified height in metres"),
     defineParameter("growingStockConstraint", "numeric", 9999, NA, NA, "The percentage of standing merchantable timber that must be retained through out the planning horizon. values [0,1]"),
-    defineParameter("harvestPriority", "character", "age DESC", NA, NA, "This sets the order from which harvesting should be conducted. Greatest priority first. DESC is decending, ASC is ascending")
+    defineParameter("harvestBlockPriority", "character", "age DESC", NA, NA, "This sets the order from which harvesting should be conducted at the block level. Greatest priority first. DESC is decending, ASC is ascending"),
+    defineParameter("harvestZonePriority", "character", "99999", NA, NA, "This sets the order from which harvesting should be conducted at the zone level. Greatest priority first e.g., dist DESC. DESC is decending, ASC is ascending"),
+    defineParameter("reportHarvestConstraints", "logical", FALSE, NA, NA, "T/F. Should the constraints be reported")
     
     ),
   inputObjects = bind_rows(
@@ -67,13 +69,14 @@ doEvent.forestryCLUS = function(sim, eventTime, eventType) {
     eventType,
     init = {
       sim <- Init(sim) #note target flow is a data.table object-- dont need to get it.
-      sim <- scheduleEvent(sim, time(sim)+ 1, "forestryCLUS", "schedule", 2)
+      sim <- scheduleEvent(sim, time(sim)+ 1, "forestryCLUS", "schedule", 3)
       sim <- scheduleEvent(sim, end(sim) , "forestryCLUS", "save", 20)
     },
     schedule = {
       sim <- setConstraints(sim)
       sim <- getHarvestQueue(sim) # This returns a candidate set of blocks or pixels that could be harvested
-      sim <- scheduleEvent(sim, time(sim) + 1, "forestryCLUS", "schedule", 2)
+      sim <- reportConstraints(sim) #WORKING ON THIS
+      sim <- scheduleEvent(sim, time(sim) + 1, "forestryCLUS", "schedule", 3)
     },
     save = {
       sim <- saveForestry(sim)
@@ -85,6 +88,7 @@ doEvent.forestryCLUS = function(sim, eventTime, eventType) {
 }
 
 Init <- function(sim) {
+
   #Check to see if a scenario object has been instantiated
   if(nrow(sim$scenario) == 0) { stop('Include a scenario description as a data.table object with columns name and description')}
   
@@ -92,7 +96,6 @@ Init <- function(sim) {
   sim$harvestReport <- data.table(scenario = character(), timeperiod = integer(), compartment = character(), target = numeric(), area= numeric(), volume = numeric(), age = numeric(), hsize = numeric(), avail_thlb= numeric(), transition_area = numeric(), transition_volume= numeric())
  
   #Remove zones as a scenario
-  dbExecute(sim$clusdb, paste0("DELETE FROM zone WHERE reference_zone not in ('",paste(P(sim, "dataLoaderCLUS", "nameZoneRasters"), sep= ' ', collapse = "', '"),"')"))
   dbExecute(sim$clusdb, paste0("DELETE FROM zoneConstraints WHERE reference_zone not in ('",paste(P(sim, "dataLoaderCLUS", "nameZoneRasters"), sep= ' ', collapse = "', '"),"')"))
   
   #For the zone constraints of type 'nh' set thlb to zero so that they are removed from harvesting -- yet they will still contribute to other zonal constraints
@@ -105,11 +108,23 @@ Init <- function(sim) {
     dbExecute(sim$clusdb, paste0("UPDATE pixels SET thlb = 0 WHERE ", paste(nhConstraints$qry, collapse = " OR ")))
   }
  
-  #For printing out rasters of harvest blocks
+  #Create the zoneManagement table used for reporting the harvesting constraints throughout the simulation
+  if(P(sim, "forestryCLUS", "reportHarvestConstraints")){
+    dbExecute(sim$clusdb, "CREATE TABLE IF NOT EXISTS zoneManagement (zoneid integer, reference_zone text, zone_column text, variable text, threshold numeric, type text, percentage numeric, multi_condition text, t_area numeric, percent numeric, timeperiod integer)")
+  }
+  
+  #Create the zonePriority table used for spatially adjusting the harvest queue
+  if(!P(sim, "forestryCLUS", "harvestZonePriority") == '99999'){
+    pzone<-dbGetQuery(sim$clusdb, paste0("SELECT zone_column from zone where reference_zone = '", P(sim, "dataLoaderCLUS", "nameZonePriorityRaster"),"'"))[[1]]
+    dbExecute(sim$clusdb, paste0("CREATE TABLE zonePriority as SELECT ",pzone,", avg(age) as age, avg(dist) as dist, avg(vol*thlb) as vol FROM pixels GROUP BY ", 
+                                 pzone))
+  }
+  
+  #Needed for printing out rasters of harvest blocks
   sim$harvestBlocks<-sim$ras
   sim$harvestBlocks[]<-0
   
-  #Set the zone contraint raster
+  #Set the zone contraint raster which maps out the number of time periods a pixel is constrained
   sim$ras.zoneConstraint<-sim$ras
   sim$ras.zoneConstraint[]<-0
   
@@ -131,10 +146,12 @@ setConstraints<- function(sim) {
   dbExecute(sim$clusdb, "UPDATE pixels SET zone_const = 0 WHERE zone_const = 1")
   
   message("....assigning zone_const")
-  zones<-dbGetQuery(sim$clusdb, "SELECT zone_column FROM zone")
+  #Get the zones that are listed
+  zones<-dbGetQuery(sim$clusdb, paste0("SELECT zone_column FROM zone WHERE reference_zone in ('",paste(P(sim, "dataLoaderCLUS", "nameZoneRasters"), sep= ' ', collapse = "', '"),"')"))
   for(i in 1:nrow(zones)){ #for each of the specified zone rasters
     numConstraints<-dbGetQuery(sim$clusdb, paste0("SELECT DISTINCT variable, type FROM zoneConstraints WHERE
                                zone_column = '",  zones[[1]][i] ,"' AND type IN ('ge', 'le')"))
+    
     if(nrow(numConstraints) > 0){
       for(k in 1:nrow(numConstraints)){
         query_parms<-data.table(dbGetQuery(sim$clusdb, paste0("SELECT t_area, type, zoneid, variable, zone_column, percentage, threshold, multi_condition, 
@@ -144,7 +161,7 @@ setConstraints<- function(sim) {
                                                         FROM zoneConstraints WHERE zone_column = '", zones[[1]][i],"' AND variable = '", 
                                                             numConstraints[[1]][k],"' AND type = '",numConstraints[[2]][k] ,"';")))
         query_parms<-query_parms[!is.na(limits) | limits > 0, ]
-        
+    
        switch(
           as.character(query_parms[1, "type"]),
             ge = {
@@ -277,12 +294,34 @@ getHarvestQueue<- function(sim) {
       partition<-sim$harvestFlow[compartment==compart, "partition"][time(sim)]
       
       #Queue pixels for harvesting. Use a nested query so that all of the block will be selected -- meet patch size objectives
-      sql<-paste0("SELECT pixelid, blockid, compartid, yieldid, height, elv, (age*thlb) as age_h, thlb, (thlb*vol) as vol_h FROM pixels WHERE blockid IN 
-                   (SELECT distinct(blockid) FROM pixels WHERE 
-                  compartid = '", compart ,"' AND zone_const = 0 AND blockid > 0 AND ", partition, "
-                  ORDER BY ", P(sim, "forestryCLUS", "harvestPriority"), " LIMIT ", as.integer(harvestTarget/50), ") AND thlb > 0 AND zone_const = 0 AND ", partition, 
-                  " ORDER BY blockid ")
-  
+      if(!P(sim,"forestryCLUS", "harvestZonePriority")== '99999'){
+        message(paste0("Using zone priority: ",P(sim,"forestryCLUS", "harvestZonePriority") ))
+        name.zone.priority<-dbGetQuery(sim$clusdb, paste0("SELECT zone_column from zone where reference_zone = '", P(sim, "dataLoaderCLUS", "nameZonePriorityRaster"),"'"))$zone_column
+        sql<-paste0("SELECT pixelid, p.blockid, compartid, yieldid, height, elv, (age*thlb) as age_h, thlb, (thlb*vol) as vol_h
+FROM pixels p
+INNER JOIN 
+(SELECT blockid, ROW_NUMBER() OVER ( 
+		ORDER BY ", P(sim, "forestryCLUS", "harvestBlockPriority"), ") as block_rank FROM blocks) b
+on p.blockid = b.blockid
+INNER JOIN 
+(SELECT ", name.zone.priority,", ROW_NUMBER() OVER ( 
+		ORDER BY ", P(sim, "forestryCLUS", "harvestZonePriority"), ") as zone_rank FROM zonePriority) a
+on p.",name.zone.priority," = a.",name.zone.priority,"
+WHERE compartid = '", compart ,"' AND zone_const = 0 AND p.blockid > 0 AND thlb > 0 AND ", partition, "
+ORDER by zone_rank, block_rank, ", P(sim, "forestryCLUS", "harvestBlockPriority"), "
+                           LIMIT ", as.integer(harvestTarget/50))
+      }else{
+        sql<-paste0("SELECT pixelid, p.blockid as blockid, compartid, yieldid, height, elv, (age*thlb) as age_h, thlb, (thlb*vol) as vol_h
+FROM pixels p
+INNER JOIN 
+(SELECT blockid, ROW_NUMBER() OVER ( 
+		ORDER BY ", P(sim, "forestryCLUS", "harvestBlockPriority"), ") as block_rank FROM blocks) b
+on p.blockid = b.blockid
+WHERE compartid = '", compart ,"' AND zone_const = 0 AND thlb > 0 AND p.blockid > 0 AND ", partition, "
+ORDER by block_rank, ", P(sim, "forestryCLUS", "harvestBlockPriority"), "
+                           LIMIT ", as.integer(harvestTarget/50))
+        
+      }
       queue<-data.table(dbGetQuery(sim$clusdb, sql))
       
       if(nrow(queue) == 0) {
@@ -297,7 +336,10 @@ getHarvestQueue<- function(sim) {
           print(paste0("Adjust harvest flow | gs constraint: ", harvestTarget))
         }
         
+        test_queue<<-queue
         queue<-queue[, cvalue:=cumsum(vol_h)][cvalue <= harvestTarget,]
+        
+        sim$harvestPixelList<-queue
         
         #Update the pixels table
         dbBegin(sim$clusdb)
@@ -305,9 +347,7 @@ getHarvestQueue<- function(sim) {
           #rs<-dbSendQuery(sim$clusdb, "UPDATE pixels SET age = 0 WHERE pixelid = :pixelid", queue[, "pixelid"])
         dbClearResult(rs)
         dbCommit(sim$clusdb)
-        
-        sim$harvestPixelList<-queue
-
+      
         #Save the harvesting raster
         sim$harvestBlocks[queue$pixelid]<-time(sim)*sim$updateInterval
         
@@ -318,6 +358,7 @@ getHarvestQueue<- function(sim) {
         
         land_coord<-sim$pts[pixelid %in% land_pixels$landing, ]
         setnames(land_coord,c("x", "y"), c("X", "Y"))
+        test98<<-land_coord
         
         #Create proj_vol for uncertainty in yields
         temp.harvestBlockList<-queue[, list(sum(vol_h), mean(height), mean(elv)), by = c("blockid", "compartid")]
@@ -338,9 +379,10 @@ getHarvestQueue<- function(sim) {
       next #No volume demanded in this compartment
     }
   }
-  
+ 
   #convert to class SpatialPoints needed for roadsCLUS
   if(!is.null(land_coord)){
+    test99<<-land_coord
     sim$landings <- SpatialPoints(land_coord[,c("X", "Y")],crs(sim$ras))
   }else{
     message("no landings")
@@ -350,6 +392,56 @@ getHarvestQueue<- function(sim) {
   return(invisible(sim))
 }
 
+reportConstraints<- function(sim) {
+  #TODO: duplicate constraints see zoneid 319 in rast.zone_cond_cw zone7 eca
+  if(P(sim, "forestryCLUS", "reportHarvestConstraints")){
+    message("....reporting harvesting constraints")
+    zones<-dbGetQuery(sim$clusdb, "SELECT zone_column FROM zone")
+    for(i in 1:nrow(zones)){ #for each of the specified zone rasters
+      numConstraints<-dbGetQuery(sim$clusdb, paste0("SELECT DISTINCT variable, type FROM zoneConstraints WHERE
+                                 zone_column = '",  zones[[1]][i] ,"' AND type IN ('ge', 'le')"))
+      
+      if(nrow(numConstraints) > 0){
+        for(k in 1:nrow(numConstraints)){
+          query_parms<-data.table(dbGetQuery(sim$clusdb, paste0("SELECT t_area, type, zoneid, variable, reference_zone, zone_column, percentage, threshold, multi_condition
+                                                          FROM zoneConstraints WHERE zone_column = '", zones[[1]][i],"' AND variable = '", 
+                                                                numConstraints[[1]][k],"' AND type = '",numConstraints[[2]][k] ,"';")))
+          switch(
+            as.character(query_parms[1, "type"]),
+            ge = {
+              if(!is.na(query_parms[1, "multi_condition"])){
+                sql<- paste0("INSERT INTO zoneManagement SELECT :zoneid as zoneid, :reference_zone as reference_zone, :zone_column as zone_column, :variable as variable, :threshold as threshold, :type as type, :percentage as percentage, :multi_condition as multi_condition, :t_area as t_area, 
+                           avg(case when ", as.character(query_parms[1, "multi_condition"])  ," then 1 else 0 end)*100 as percent, ", as.integer(time(sim)) ," as timeperiod  from pixels where ",zones[[1]][i], " = :zoneid")
+              }else{
+                sql<- paste0("INSERT INTO zoneManagement SELECT :zoneid as zoneid, :reference_zone as reference_zone, :zone_column as zone_column, :variable as variable, :threshold as threshold, :type as type, :percentage as percentage, :multi_condition as multi_condition, :t_area as t_area, 
+                           avg(case when ", numConstraints[[1]][k]  ," > :threshold then 1 else 0 end)*100 as percent, ", as.integer(time(sim)) ," as timeperiod  from pixels where ",zones[[1]][i], " = :zoneid")
+              }
+              
+            },
+            le = {
+              if(!is.na(query_parms[1, "multi_condition"])){
+                sql<- paste0("INSERT INTO zoneManagement SELECT :zoneid as zoneid, :reference_zone as reference_zone, :zone_column as zone_column, :variable as variable, :threshold as threshold, :type as type, :percentage as percentage, :multi_condition as multi_condition, :t_area as t_area, 
+                           avg(case when ", as.character(query_parms[1, "multi_condition"])  ," then 1 else 0 end)*100 as percent, ", as.integer(time(sim)) ," as timeperiod  from pixels where ",zones[[1]][i], " = :zoneid")
+              }else{
+                sql<- paste0("INSERT INTO zoneManagement SELECT :zoneid as zoneid, :reference_zone as reference_zone, :zone_column as zone_column, :variable as variable, :threshold as threshold, :type as type, :percentage as percentage, :multi_condition as multi_condition, :t_area as t_area, 
+                           avg(case when ", numConstraints[[1]][k]  ," < :threshold then 1 else 0 end)*100 as percent, ", as.integer(time(sim)) ," as timeperiod  from pixels where ",zones[[1]][i]," = :zoneid")
+              }
+            }
+          )
+          
+          dbBegin(sim$clusdb)
+          rs<-dbSendQuery(sim$clusdb, sql, query_parms[,c("zoneid", "reference_zone", "zone_column", "variable", "threshold", "type", "percentage", "multi_condition", "t_area")])
+          dbClearResult(rs)
+          dbCommit(sim$clusdb)
+          
+          zoneManagement<<-dbGetQuery(sim$clusdb, "SELECT * FROM zoneManagement")
+          
+        }
+      }
+    }
+  }
+  return(invisible(sim))
+}
 
 .inputObjects <- function(sim) {
   return(invisible(sim))

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_100Miletsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_100Miletsa.Rmd
@@ -85,7 +85,9 @@ ECCC in  Wells Gray South = rast.zone_cond_eccc_wells_gray_south_crithab_or_herd
 - from base case: 
   - Starting in 2012, the initial harvest level in the 150-year base case was set at 2.0 million cubic metres per year.  This rate, which is the level of the AAC determined in 2006, can be maintained for seven years.After 2019, the harvest level decreases to 890 000 cubic metres per year and remains at this level for 48 years (2067), after which it begins to increase to the long-term sustainable level of 1.6 million cubic metres per year in 2086. 
 
--  I tested a harvest flow of 1,000,000m^3^/year (5,000,000m^3^/5-year), 1.25M, 1.5M, 1.35M, 1.45M, 1.4M, 1.425M - stable at 1.4M
+-  I tested a harvest flow of 1,500,000m^3^/year (7,500,000m^3^/5-year), 
+
+- stable at 
 
 
 
@@ -133,11 +135,11 @@ parameters <- list(
                                              "rast.zone_cond_uwr",
                                              "rast.zone_cond_fsw", 
                                              "rast.zone_cond_nharv", 
-                                             "rast.zone_cond_cw", 
+                                             "rast.zone_cond_cw" 
                               # "rast.zone_cond_noharvest_wells_gray_north_crithab_or_herd"
                               # "rast.zone_cond_noharvest_wells_gray_south_crithab_or_herd"
                               # "rast.zone_cond_eccc_wells_gray_north_crithab_or_herd"
-                               "rast.zone_cond_eccc_wells_gray_south_crithab_or_herd"   
+                              # "rast.zone_cond_eccc_wells_gray_south_crithab_or_herd"   
                                                ),
                            nameZoneTable = "zone_constraints",
                            nameYieldsRaster = "rast.ycid_vdyp",
@@ -171,7 +173,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",
@@ -200,8 +202,10 @@ modules <- list("dataLoaderCLUS",
 # rsf_model_coeff <- data.table (getTableQuery ("SELECT * FROM rsf_model_coeff WHERE population = 'DU7' and  species = 'caribou' and season IN ('A')"))
 # rsf_model_coeff[, bounds := 'rast.bc_crithab_and_herd']
 
-# scenario = data.table (name = "OnehundredMile_bau",
-#                        description = "Business-as-usual case; sustainable flow = 1,400,000m^3^/year. Adjacency was set to 3m.")
+
+
+scenario = data.table (name = "OnehundredMile_bau",
+                       description = "Business-as-usual case; sustainable flow = 1,400,000m^3^/year. Adjacency was set to 3m.")
 # scenario = data.table (name = "OnehundredMile_wells_north_nh",
 #                        description = "No harvest in Wells Gray North critical habitat that overlap with the harvest unit (e.g., TSA or TFL). Adjacency was set to 3m.")
 # scenario = data.table (name = "OnehundredMile_wells_north_ch_hele0d_m15d",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_arrowtsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_arrowtsa.Rmd
@@ -178,7 +178,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_cascadiatsa_cariboo_chilcotin.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_cascadiatsa_cariboo_chilcotin.Rmd
@@ -159,7 +159,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_cascadiatsa_kootenay_block.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_cascadiatsa_kootenay_block.Rmd
@@ -141,7 +141,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_cascadiatsa_okanagan_columbia.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_cascadiatsa_okanagan_columbia.Rmd
@@ -149,7 +149,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_cranbrooktsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_cranbrooktsa.Rmd
@@ -159,7 +159,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_dawsontsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_dawsontsa.Rmd
@@ -213,7 +213,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_fisher_quesnel.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_fisher_quesnel.Rmd
@@ -138,7 +138,7 @@ parameters <- list(
                        tableCaribouHerd = "public.caribou_herd_vat"), 
   fisherCLUS = list(nameRasFisherTerritory = c('rast.zone_cond_fisher_sb_dry','rast.zone_cond_fisher_sb_wet','rast.zone_cond_fisher_dry'),
                     nameRasWetlands = 'rast.wetland'),
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              recovery = 40),

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_gbrnorthtsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_gbrnorthtsa.Rmd
@@ -137,7 +137,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_gbrsouthtsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_gbrsouthtsa.Rmd
@@ -138,7 +138,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_goldentsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_goldentsa.Rmd
@@ -206,7 +206,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_invermeretsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_invermeretsa.Rmd
@@ -140,7 +140,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_kamloopstsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_kamloopstsa.Rmd
@@ -182,7 +182,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_kootenaylaketsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_kootenaylaketsa.Rmd
@@ -161,7 +161,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_lakestsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_lakestsa.Rmd
@@ -143,7 +143,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_mackenzie_tsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_mackenzie_tsa.Rmd
@@ -228,7 +228,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_moricetsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_moricetsa.Rmd
@@ -162,7 +162,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_okanagantsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_okanagantsa.Rmd
@@ -190,7 +190,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_princegeorgetsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_princegeorgetsa.Rmd
@@ -170,7 +170,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_quesneltsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_quesneltsa.Rmd
@@ -85,10 +85,10 @@ ECCC in Chilcotin = rast.zone_cond_eccc_itcha_ilgachuz_crithab_or_herd
 ## 'harvestFlow'
 from 2016 analysis report:  maximum even flow harvest was 2,139,000m^3^/year; from detemrination, June 6, 2017, the  AAC was set at 2,607,000 cubic metres 
 
-- First, I tested a harvest flow of 2,139,00m^3^/year but this was too high so I tried 2,000,000, then 2,800,000 and finally settled on 1,700,000 which worked.
+the predicted sustainable harvest flow in Quesnel was betweeen 1,617,000 and 2,139,000 (https://www2.gov.bc.ca/assets/gov/farming-natural-resources-and-industry/forestry/stewardship/forest-analysis-inventory/tsr-annual-allowable-cut/quesnel_tsa_discussion_paper.pdf) pg 12
 
+- First, I tested a harvest flow of 2,139,000m^3^/year
 
-why was this model max even flow at 79% of previosu model? maybe adjacney?, maybe min. volume? or maybe harvest queue? It says in the discussion paper that they expect the average age of harvest to decline. In particular in 50 yrs from now they forcast stands of 50 yrs or older to contribute ~57% of the harvest. Possibly I should have changed the age constraint to reflect this.
 
 - I used 150 m3/ha as minimum harvest volume
 
@@ -125,7 +125,7 @@ parameters <- list(
                                            "rast.zone_cond_uwr", 
                                            "rast.zone_cond_nharv", 
                                            "rast.zone_cond_fsw", 
-                                           "rast.zone_cond_cw",
+                                           "rast.zone_cond_cw"
                                            # "rast.zone_cond_noharvest_barkerville_crithab_or_herd"
                                            # "rast.zone_cond_noharvest_itcha_ilgachuz_crithab_or_herd"
                                            # "rast.zone_cond_noharvest_narrow_lake_crithab_or_herd"
@@ -137,7 +137,7 @@ parameters <- list(
                                            # "rast.zone_cond_eccc_narrow_lake_crithab_or_herd",
                                            # "rast.zone_cond_eccc_north_cariboo_crithab_or_herd",
                                            # "rast.zone_cond_eccc_tweedsmuir_crithab_or_herd",
-                                            "rast.zone_cond_eccc_wells_gray_north_crithab_or_herd"
+                                           # "rast.zone_cond_eccc_wells_gray_north_crithab_or_herd"
                                            ),
                                            
                                            
@@ -173,12 +173,12 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance)
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",
                              recovery = 40),
-  uploaderCLUS = list(aoiName = 'quesnel_tsa', # name of the schema that gets uplaoded to postgres
+  uploaderCLUS = list(aoiName = 'test_tsa', # name of the schema that gets uplaoded to postgres
                       dbInfo  = list(keyring::key_get("vmdbhost", keyring="postgreSQL"), 
                                      keyring::key_get("vmdbuser", keyring="postgreSQL"), 
                                      keyring::key_get("vmdbpass", keyring="postgreSQL"),  
@@ -202,8 +202,8 @@ modules <- list("dataLoaderCLUS",
 # rsf_model_coeff <- data.table (getTableQuery ("SELECT * FROM rsf_model_coeff WHERE population = 'DU7' and  species = 'caribou' and season IN ('A')"))
 # rsf_model_coeff[, bounds := 'rast.bc_crithab_and_herd']
 
-# scenario = data.table (name = "quesnel_bau",
-#                        description = "Business as usual (BAU). Adjacency was set to 3m.")
+scenario = data.table (name = "quesnel_bau",
+                       description = "Business as usual (BAU). Adjacency was set to 3m. Even harvest flow = 2,139,000m3/year")
 # scenario = data.table (name = "quesnel_chil_nh",
 #                        description = "No harvest in Chilcotin herds and habitat that overlap with the harvest unit (e.g., TSA or TFL). Adjacency was set to 3m.")
 # scenario = data.table (name = "quesnel_chil_ch_hele0d_m15d",
@@ -226,9 +226,8 @@ modules <- list("dataLoaderCLUS",
 #                        description = "No harvest in Barkerville high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Barkerville matrix critical habitat. Adjacency was set to 3m.")
 # scenario = data.table (name = "quesnel_wells_north_nh",
 #                        description = "No harvest in Wells Gray North critical habitat that overlap with the harvest unit (e.g., TSA or TFL). Adjacency was set to 3m.")
-
-scenario = data.table (name = "quesnel_wells_north_ch_hele0d_m15d",
-                       description = "No harvest in Wells Gray North high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Wells Gray North matrix critical habitat. Adjacency was set to 3m.")
+# scenario = data.table (name = "quesnel_wells_north_ch_hele0d_m15d",
+#                        description = "No harvest in Wells Gray North high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Wells Gray North matrix critical habitat. Adjacency was set to 3m.")
 
 
 harvestFlow <- rbindlist(list(data.table(compartment ="Quesnel_TSA",
@@ -237,8 +236,8 @@ harvestFlow <- rbindlist(list(data.table(compartment ="Quesnel_TSA",
                                                       to = 2218, 
                                                       by = 5),
                                                 1), 
-                                     flow = 8500000) # 1,700,000 m3/yr 
-))# interestingly the predicted sustainable harvest flow in Quesnel was betweeen 1,617,000 and 2,139,000 (https://www2.gov.bc.ca/assets/gov/farming-natural-resources-and-industry/forestry/stewardship/forest-analysis-inventory/tsr-annual-allowable-cut/quesnel_tsa_discussion_paper.pdf) pg 12
+                                     flow = 10695000) # 2,139,000 m3/yr 
+))
 
 #harvestFlow<-rbindlist(list(harvestFlowA,harvestFlowB,harvestFlowC)) # if > 1 harvest flow
 

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_revelstoketsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_revelstoketsa.Rmd
@@ -83,15 +83,15 @@ ECCC in Columbia North, Columbia South and Frisby-Boulder = rast.zone_cond_eccc_
       - 'vol DESC', i.e., descending volume (highest volume first)
 
 ## 'harvestFlow'
-- based on interpretation of analysis report, I tested a harvest flow of 200,000m^3^/year (1,000,000m^3^/5-year); 150,000, 175,000, 165,000, 160,000, then 155,000
+- based on interpretation of analysis report, I tested a harvest flow of 200,000m^3^/year (1,000,000m^3^/5-year); 250,000, 225,000, 215,000, 205,000, 210,000; used 210,000 as bau
 
-from detemiantion: used 'oldest first' priority queue
+from detemiantion: used 'oldest first' priority queue; here I used the same 
 
 From analysis report: large majority of minimum harvest ages used in the base case scenario was based on achieving 95% of the stands maximum mean annual increment (MAI). 
 
 - I used 150 m3/ha as minimum harvest volume instead
 
-For cutblock adjacency, I used 3 m adjacncey; in analysis report: 25% of the THLB in each LU was allowed to be less than the greenup age (13 years old)
+For cutblock adjacency, I used 3 m adjacency; in analysis report: 25% of the THLB in each LU was allowed to be less than the greenup age (13 years old)
 
 ## Modify Constraints
 
@@ -103,8 +103,15 @@ clusdb <- dbConnect(RSQLite::SQLite(), dbname = paste0(here::here(), "/R/SpaDES-
 # STEP 2: View the constraints available to a zone
 zoneconstraints<-dbGetQuery(clusdb, "SELECT * from zoneConstraints WHERE reference_zone = 'rast.zone_cond_reve_area'") # Note: the reference_zone is the name of the raster in the rast schema. If there is no 'WHERE' clause this may return 1000's of zones
 
+
 # COLUMBIA NORTH Update the constraints available to a zone as specified in the scenario
-dbExecute(clusdb, "UPDATE zoneconstraints SET type = '' where reference_zone = 'rast.zone_cond_reve_area' AND (zoneid = 3) OR (zoneid = 4) OR (zoneid = 5) OR (zoneid = 6) OR (zoneid = 9) OR (zoneid = 10) OR (zoneid = 11) OR (zoneid = 12) OR (zoneid = 15) OR (zoneid = 16) OR (zoneid = 17) OR (zoneid = 18) OR (zoneid = 21) OR (zoneid = 22) OR (zoneid = 23) OR (zoneid = 24)") #This will set Columbia South and Frisby Boulder as 'harvestable' areas
+#This will set Columbia North core as no harvest areas 
+dbExecute(clusdb, "UPDATE zoneconstraints SET type = 'nh' where reference_zone = 'rast.zone_cond_reve_area' AND (zoneid = 1) OR (zoneid = 7) OR (zoneid = 13) OR (zoneid = 19)")
+dbExecute(clusdb, "UPDATE zoneconstraints SET type = 'ge' where reference_zone = 'rast.zone_cond_reve_area' AND (zoneid = 2) OR (zoneid = 8) OR (zoneid = 14) OR (zoneid = 20)") #This will set Columbia North matrix as constrained areas 
+
+#This will set Columbia South and Frisby Boulder as 'harvestable' areas
+dbExecute(clusdb, "UPDATE zoneconstraints SET type = '' where reference_zone = 'rast.zone_cond_reve_area' AND (zoneid = 3) OR (zoneid = 4) OR (zoneid = 5) OR (zoneid = 6) OR (zoneid = 9) OR (zoneid = 10) OR (zoneid = 11) OR (zoneid = 12) OR (zoneid = 15) OR (zoneid = 16) OR (zoneid = 17) OR (zoneid = 18) OR (zoneid = 21) OR (zoneid = 22) OR (zoneid = 23) OR (zoneid = 24)") 
+
 
 # COLUMBIA SOUTH 
 dbExecute(clusdb, "UPDATE zoneconstraints SET type = 'nh' where reference_zone = 'rast.zone_cond_reve_area' AND (zoneid = 3) OR (zoneid = 9) OR (zoneid = 15) OR (zoneid = 21)") #This will set Columbia South core as no harvest areas 
@@ -113,10 +120,11 @@ dbExecute(clusdb, "UPDATE zoneconstraints SET type = 'ge' where reference_zone =
 
 dbExecute(clusdb, "UPDATE zoneconstraints SET type = '' where reference_zone = 'rast.zone_cond_reve_area' AND (zoneid = 1) OR (zoneid = 2) OR (zoneid = 7) OR (zoneid = 8) OR (zoneid = 13) OR (zoneid = 14) OR (zoneid = 19) OR (zoneid = 20)") #This will set Columbia North and Frisby Boulder as 'harvestable' areas
 
-# Frisby-Boulder
-dbExecute(clusdb, "UPDATE zoneconstraints SET type = 'nh' where reference_zone = 'rast.zone_cond_reve_area' AND (zoneid = 5) OR (zoneid = 11) OR (zoneid = 17) OR (zoneid = 23)") #This will set Columbia South core as no harvest areas 
 
-dbExecute(clusdb, "UPDATE zoneconstraints SET type = 'ge' where reference_zone = 'rast.zone_cond_reve_area' AND (zoneid = 6) OR (zoneid = 12) OR (zoneid = 18) OR (zoneid = 24)") #This will set Columbia South matrix as constrained areas 
+# Frisby-Boulder
+dbExecute(clusdb, "UPDATE zoneconstraints SET type = 'nh' where reference_zone = 'rast.zone_cond_reve_area' AND (zoneid = 5) OR (zoneid = 11) OR (zoneid = 17) OR (zoneid = 23)") #This will set Frisby-Boulder core as no harvest areas 
+
+dbExecute(clusdb, "UPDATE zoneconstraints SET type = 'ge' where reference_zone = 'rast.zone_cond_reve_area' AND (zoneid = 6) OR (zoneid = 12) OR (zoneid = 18) OR (zoneid = 24)") #This will set Frisby-Boulder matrix as constrained areas 
 
 dbExecute(clusdb, "UPDATE zoneconstraints SET type = '' where reference_zone = 'rast.zone_cond_reve_area' AND (zoneid = 3) OR (zoneid = 4) OR (zoneid = 9) OR (zoneid = 10) OR (zoneid = 15) OR (zoneid = 16) OR (zoneid = 21) OR (zoneid = 22)") #This will set Columbia North and Frisby Boulder as 'harvestable' areas
 
@@ -156,16 +164,16 @@ parameters <- list(
                                                "rast.zone_cond_nharv",
                                                "rast.zone_cond_cw",
                                                #"rast.zone_cond_reve_area"
-                                               # "rast.zone_cond_noharvest_monashee_crithab_or_herd"
-                                               # "rast.zone_cond_noharvest_frisby_boulder_crithab_or_herd"
-                                               # "rast.zone_cond_noharvest_columbia_south_crithab_or_herd",
-                                               # "rast.zone_cond_noharvest_central_rockies_crithab_or_herd"
-                                               # "rast.zone_cond_noharvest_columbia_north_crithab_or_herd"
-                                                # "rast.zone_cond_eccc_monashee_crithab_or_herd"
-                                               # "rast.zone_cond_eccc_frisby_boulder_crithab_or_herd"
-                                               # "rast.zone_cond_eccc_columbia_south_crithab_or_herd"
-                                               # "rast.zone_cond_eccc_central_rockies_crithab_or_herd"
-                                                "rast.zone_cond_eccc_columbia_north_crithab_or_herd"
+                                #"rast.zone_cond_noharvest_monashee_crithab_or_herd",
+                                #"rast.zone_cond_noharvest_frisby_boulder_crithab_or_herd",
+                                #"rast.zone_cond_noharvest_columbia_south_crithab_or_herd",
+                                #"rast.zone_cond_noharvest_central_rockies_crithab_or_herd",
+                                #"rast.zone_cond_noharvest_columbia_north_crithab_or_herd"
+                                #"rast.zone_cond_eccc_monashee_crithab_or_herd",
+                                #"rast.zone_cond_eccc_frisby_boulder_crithab_or_herd",
+                                #"rast.zone_cond_eccc_columbia_south_crithab_or_herd",
+                                #"rast.zone_cond_eccc_central_rockies_crithab_or_herd",
+                                "rast.zone_cond_eccc_columbia_north_crithab_or_herd"
                                                ),
                            nameZoneTable = "zone_constraints",
                            nameYieldsRaster = "rast.ycid_vdyp",
@@ -185,7 +193,7 @@ parameters <- list(
                       nameCutblockRaster ="rast.cns_cut_bl",
                       useLandingsArea = FALSE, 
                       useSpreadProbRas = FALSE),
-  forestryCLUS = list(harvestPriority = "dist, age DESC, vol DESC",
+  forestryCLUS = list(harvestPriority = "age DESC",
                       adjacencyConstraint = 3),
   growingStockCLUS = list (periodLength = 5),
   roadCLUS = list(roadMethod = 'pre', 
@@ -199,7 +207,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, 
                        nameRasCaribouHerd = "rast.caribou_herd", 
                        tableCaribouHerd = "public.caribou_herd_vat"), 
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval = 1, # should be 1 if using constraints on 'dist' (disturbance)
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",
@@ -228,54 +236,57 @@ modules <- list("dataLoaderCLUS",
 # rsf_model_coeff <- data.table (getTableQuery ("SELECT * FROM rsf_model_coeff WHERE population = 'DU7' and  species = 'caribou' and season IN ('A')"))
 # rsf_model_coeff[, bounds := 'rast.bc_crithab_and_herd']
 
+
+### SCENARIOS ###
 # scenario = data.table (name = "revelstoke_bau",
-#                        description = "Business-as-usual case; sustainable flow = 155,000m^3^/year. Adjacency was set to 3m.")
+#                        description = "Business-as-usual case; sustainable flow = 210,000m^3^/year. Adjacency was set to 3m.")
 # scenario = data.table (name = "revelstoke_colnsfb_nh",
-#                        description = "No harvest in all Columbia North, Columbia South and Frisby-Boulder critical habitat. Adjacency was set to 3m.")
+#                        description = "No harvest in all Columbia North, Columbia South and Frisby-Boulder critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_colnsfb_ch_he0d_m15d",
-#                        description = "No harvest in Columbia North, Columbia South and Frisby-Boulder high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Columbia North, Columbia South and Frisby-Boulder matrix critical habitat. Adjacency was set to 3m.")
+#                        description = "No harvest in Columbia North, Columbia South and Frisby-Boulder high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Columbia North, Columbia South and Frisby-Boulder matrix critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_all_nh",
-#                        description = "No harvest in all critical habitat of all herds that overlap with the TSA. Adjacency was set to 3m.")
+#                        description = "No harvest in all critical habitat of all herds that overlap with the TSA. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_all_ch_he0d_m15d",
-#                        description = "No harvest in high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in matrix critical habitat of all herds that overlap the TSA. Adjacency was set to 3m.")
+#                        description = "No harvest in high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in matrix critical habitat of all herds that overlap the TSA. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_columbia_north_nh",
-#                        description = "No harvest in all Columbia North critical habitat. Adjacency was set to 3m.")
-# scenario = data.table (name = "revelstoke_columbia_north_he0d_m15d",
-#                        description = "No harvest in Columbia North high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Columbia North matrix critical habitat. Adjacency was set to 3m.")
+#                        description = "No harvest in all Columbia North critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
+scenario = data.table (name = "revelstoke_columbia_north_he0d_m15d",
+                       description = "No harvest in Columbia North high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Columbia North matrix critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_central_rockies_nh",
-#                        description = "No harvest in all Central Rockies critical habitat. Adjacency was set to 3m.")
+#                        description = "No harvest in all Central Rockies critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_central_rockies_he0d_m15d",
-#                        description = "No harvest in Central Rockies high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Central Rockies matrix critical habitat. Adjacency was set to 3m.")
+#                        description = "No harvest in Central Rockies high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Central Rockies matrix critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_columbia_south_nh",
-#                        description = "No harvest in all Columbia South critical habitat. Adjacency was set to 3m.")
+#                        description = "No harvest in all Columbia South critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_columbia_south_he0d_m15d",
-#                        description = "No harvest in Columbia South high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Columbia South matrix critical habitat. Adjacency was set to 3m.")
+#                        description = "No harvest in Columbia South high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Columbia South matrix critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_frisby_boulder_nh",
-#                        description = "No harvest in all Frisby Boulder critical habitat. Adjacency was set to 3m.")
+#                        description = "No harvest in all Frisby Boulder critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_frisby_boulder_he0d_m15d",
-#                        description = "No harvest in Frisby Boulder high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Frisby Boulder matrix critical habitat. Adjacency was set to 3m.")
+#                        description = "No harvest in Frisby Boulder high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Frisby Boulder matrix critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_monashee_nh",
-#                        description = "No harvest in all Monashee critical habitat. Adjacency was set to 3m.")
+#                        description = "No harvest in all Monashee critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_monashee_he0d_m15d",
-#                        description = "No harvest in Monashee high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Monashee matrix critical habitat. Adjacency was set to 3m.")
+#                        description = "No harvest in Monashee high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Monashee matrix critical habitat. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_ernst",
-#                        description = "No harvest in Columbia North, Columbia South and Frisby-Boulder high elevation critical habitat areas as defined by Bevan Ernst, maximum 35% buffered disturbance (15% harvest) in Columbia North, Columbia South and Frisby-Boulder matrix critical habitat areas as defined by Bevan Ernst. Adjacency was set to 3m.")
+#                        description = "No harvest in Columbia North, Columbia South and Frisby-Boulder high elevation critical habitat areas as defined by Bevan Ernst, maximum 35% buffered disturbance (15% harvest) in Columbia North, Columbia South and Frisby-Boulder matrix critical habitat areas as defined by Bevan Ernst. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_columbia_north_he10d_m15d",
-#                        description = "No harvest in Columbia North high elevation critical habitat areas as defined by Bevan Ernst, maximum 35% buffered disturbance (15% harvest) in Columbia North martix habitat areas as defined by Bevan Ernst. Adjacency was set to 3m.")
+#                        description = "No harvest in Columbia North high elevation critical habitat areas as defined by Bevan Ernst, maximum 35% buffered disturbance (15% harvest) in Columbia North martix habitat areas as defined by Bevan Ernst. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
 # scenario = data.table (name = "revelstoke_columbia_south_he10d_m15d",
-#                        description = "No harvest in Columbia South high elevation critical habitat areas as defined by Bevan Ernst, maximum 35% buffered disturbance (15% harvest) in Columbia South martix habitat areas as defined by Bevan Ernst. Adjacency was set to 3m.")
-# scenario = data.table (name = "revelstoke_frisby_boulder_he10d_m15d",
-#                        description = "No harvest in Frisby Boulder high elevation critical habitat areas as defined by Bevan Ernst, maximum 35% buffered disturbance (15% harvest) in Frisby Boulder martix habitat areas as defined by Bevan Ernst. Adjacency was set to 3m.")
+#                        description = "No harvest in Columbia South high elevation critical habitat areas as defined by Bevan Ernst, maximum 35% buffered disturbance (15% harvest) in Columbia South martix habitat areas as defined by Bevan Ernst. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
+scenario = data.table (name = "revelstoke_frisby_boulder_he10d_m15d",
+                       description = "No harvest in Frisby Boulder high elevation critical habitat areas as defined by Bevan Ernst, maximum 35% buffered disturbance (15% harvest) in Frisby Boulder martix habitat areas as defined by Bevan Ernst. Adjacency was set to 3m. Flow = 210,000m^3^/year.")
+
+
+
 # scenario = data.table (name = "revelstoke_bau_v2",
-#                        description = "Business-as-usual case; sustainable flow = 155,000m^3^/year. Adjacency was set to 3m.")
+#                        description = "Business-as-usual case; sustainable flow = 250,000m^3^/year. Adjacency was set to 3m.")
 # scenario = data.table (name = "revelstoke_colnsfb_nh_v2",
 #                        description = "No harvest in all Columbia North, Columbia South and Frisby-Boulder critical habitat. Sustainable flow = 155,000m^3^/year. Adjacency was set to 3m.")
 # scenario = data.table (name = "revelstoke_columbia_north_nh_v2",
 #                        description = "No harvest in all Columbia North critical habitat. Sustainable flow = 155,000m^3^/year. Adjacency was set to 3m.")
-
-
-scenario = data.table (name = "revelstoke_columbia_north_he0d_m15d_v2",
-                       description = "No harvest in Columbia North high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Columbia North matrix critical habitat. Sustainable flow = 155,000m^3^/year. Adjacency was set to 3m.")
+# scenario = data.table (name = "revelstoke_columbia_north_he0d_m15d_v2",
+#                        description = "No harvest in Columbia North high elevation critical habitat, maximum 35% buffered disturbance (15% harvest) in Columbia North matrix critical habitat. Sustainable flow = 155,000m^3^/year. Adjacency was set to 3m.")
 
 
 
@@ -286,7 +297,7 @@ harvestFlow <- rbindlist(list(data.table(compartment ="Revelstoke_TSA",
                                                          to = 2218, 
                                                          by = 5),
                                                     1), 
-                                         flow = 775000) # 155,000m^3^/year
+                                         flow = 1050000) # 210,000m^3^/year
 ))
 
 #harvestFlow<-rbindlist(list(harvestFlowA,harvestFlowB,harvestFlowC)) # if > 1 harvest flow

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_robonvalleytsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_robonvalleytsa.Rmd
@@ -211,7 +211,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl14.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl14.Rmd
@@ -141,7 +141,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval = 1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl18.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl18.Rmd
@@ -140,7 +140,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval = 1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl23.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl23.Rmd
@@ -183,7 +183,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval = 1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl30.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl30.Rmd
@@ -141,7 +141,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval = 1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl33.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl33.Rmd
@@ -143,7 +143,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl48.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl48.Rmd
@@ -205,7 +205,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl48_volumebyarea_example.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl48_volumebyarea_example.Rmd
@@ -203,7 +203,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl52.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl52.Rmd
@@ -155,7 +155,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl53.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl53.Rmd
@@ -141,7 +141,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval = 1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl55.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl55.Rmd
@@ -168,7 +168,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval = 1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl56.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_tfl56.Rmd
@@ -175,7 +175,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/R/SpaDES-modules/forestryCLUS/forestryCLUS_williamslaketsa.Rmd
+++ b/R/SpaDES-modules/forestryCLUS/forestryCLUS_williamslaketsa.Rmd
@@ -157,7 +157,7 @@ parameters <- list(
   survivalCLUS = list (caribou_herd_density = 0.05, # assign what is appropriate for the herd
                        nameRasCaribouHerd = "rast.caribou_herd", # raster of herd boundaries
                        tableCaribouHerd = "public.caribou_herd_vat"), # look-up table of herd names
-  disturbanceCalcCLUS = list(calculateInterval = 5, 
+  disturbanceCalcCLUS = list(calculateInterval =  1, # should be 1 if using constraints on 'dist' (disturbance) 
                              criticalHabitatTable = "public.vat_bc_crithab_and_herd",
                              criticalHabRaster = "rast.bc_crithab_and_herd",
                              permDisturbanceRaster = "rast.mine_ag_wind_rail",

--- a/SQL/deleteDupsNoPrimaryKey.sql
+++ b/SQL/deleteDupsNoPrimaryKey.sql
@@ -1,0 +1,11 @@
+DELETE   FROM zone_constraints T1
+  USING       zone_constraints T2
+WHERE  T1.ctid    < T2.ctid       -- select the "older" ones
+  AND T1.zoneid  = T2.zoneid 
+  AND  T1.reference_zone    = T2.reference_zone       -- list columns that define duplicates
+  AND  T1.ndt = T2.ndt
+  AND  T1.variable = T2.variable
+  AND  T1.threshold = T2.threshold
+  AND  T1.type = T2.type
+  AND  T1.percentage = T2.percentage
+  ;


### PR DESCRIPTION
* added new priority

* Set landing to the pixel thats that closest to a disturbance. Added 'dist' to the blocks table to be updated

* switched order so that blocks get updated before they are harvested

* adding reportingZoneConstraints function to allow user to select zones as a prioirty for harvesting

* creating reportingConstraints functions

* testing the new queue query

* setting up reporting for constraints

* create logic for reportingHarvestConstraints

* line 160: added 'vol' and 'dist' columns

* testing reve

* added 'dist' column to pixels table

* debugging issue with landing = NA

* reportingHarvestConstraints working -- needs more testing outside of Quesnel

* fixed bug: setBlocksTable -- INSERT had the wrong order

* removed query adding the dist vairable to pixels table

* set landing as pixel closest to disturbance

* attempt to fix bug with NULL outcome --ie no cutblocks < 20 years

* Removing empty data.tables in a list

* fixed bug; now allows for 'empty' tables to be merged

* Delete pgpass.conf

* cutblock not working?

* empty table bug still there....

* updated scenarios with fixed harvest queue

* swapped out merge in the reduce command for full_join; this keeps all NA values

* finished updated revelstoke scenarios

* testing reportingConstraints for multi-conditions

* make disturbanxe interval = 1; necessary for constraining on disturbance (dist)

* updating sceanrios

* update management areas

* added nameZonePriorityRaster

* fixed the summaries to not display the join

* added the zone priority queue

* updated bc boundary data

* add BC bounds for new scenarios

* fix bug: no roads in forestState object -- calling the query before roadCLUS was run

* fixed bug: included thlb > 0 in queue query

* removed output of outPts to global ENV

* init

Co-authored-by: Muhly <Tyler.Muhly@gov.bc.ca>